### PR TITLE
Use electrode-cdn-file-loader

### DIFF
--- a/config/webpack/partial/images.js
+++ b/config/webpack/partial/images.js
@@ -4,6 +4,7 @@ var archetype = require("../../archetype");
 var mergeWebpackConfig = archetype.devRequire("webpack-partial").default;
 var fileLoader = archetype.devRequire.resolve("file-loader");
 var isomorphicLoader = archetype.devRequire.resolve("isomorphic-loader");
+var cdnLoader = archetype.devRequire.resolve('electrode-cdn-file-loader');
 
 module.exports = function () {
   return function (config) {
@@ -12,7 +13,7 @@ module.exports = function () {
         loaders: [{
           name: "images",
           test: /\.(jpe?g|png|gif|svg)(\?\S*)?$/i,
-          loader: fileLoader + "?limit=10000!" + isomorphicLoader
+          loader: cdnLoader + "?limit=10000!" + isomorphicLoader
         }]
       }
     });


### PR DESCRIPTION
Uses the recently open sources `electrode-cdn-file-loader` package for feature parity with internal archetype.