### PR TITLE
Remove publicPath from extracted CSS

### DIFF
--- a/config/webpack/partial/extract.js
+++ b/config/webpack/partial/extract.js
@@ -52,14 +52,14 @@ module.exports = function () {
     var loaders = [{
       name: "extract-css",
       test: /\.css$/,
-      loader: ExtractTextPlugin.extract(styleLoader, cssQuery)
+      loader: ExtractTextPlugin.extract(styleLoader, cssQuery, {publicPath: ""})
     }];
 
     if (!cssModuleSupport) {
       loaders.push({
         name: "extract-stylus",
         test: /\.styl$/,
-        loader: ExtractTextPlugin.extract(styleLoader, stylusQuery)
+        loader: ExtractTextPlugin.extract(styleLoader, stylusQuery, {publicPath: "" })
       });
     }
 


### PR DESCRIPTION
@jmcriffey I'll open a PR on the actual OSS archetype once I've verified this fix with a Jenkins build